### PR TITLE
Add the ability to build and push to artifactory

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -81,6 +81,7 @@ pipeline {
         }
       }
     }
+
     stage('Push to Artifactory') {
         when {
           branch 'master'
@@ -91,6 +92,7 @@ pipeline {
               sh "jx step changelog --generate-yaml=false --version v\$(cat ../../VERSION)"
               // release the helm chart
               sh "make release && make print"
+            }
           }
         }
       }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -39,7 +39,7 @@ pipeline {
             sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
             sh "jx step tag --version \$PR_VERSION"
             sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
-            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make preview && make print"
 
             script {
                 currentBuild.displayName = PR_VERSION

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -24,8 +24,10 @@ pipeline {
             sh "jx step git credentials"
 
             // Make Test
-            sh "git clone git://github.com/fsa-streamotion/exposecontroller.git \$GOPATH/src/github.com/jenkins-x/exposecontroller"
-            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller && make test"
+            // sh "git clone git://github.com/fsa-streamotion/exposecontroller.git \$GOPATH/src/github.com/jenkins-x/exposecontroller"
+            // sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller && make test"
+            sh "mkdir -p \$GOPATH/src/github.com/jenkins-x/exposecontroller"
+            sh "cp . \$GOPATH/src/github.com/jenkins-x/exposecontroller"
 
             // Copy binary
             sh "mkdir out"

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -39,7 +39,7 @@ pipeline {
             sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
             sh "jx step tag --version \$PR_VERSION"
             sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
-            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller && make preview && make print"
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make preview && make print"
 
             script {
                 currentBuild.displayName = PR_VERSION
@@ -92,7 +92,7 @@ pipeline {
           container('go') {
             sh "jx step changelog --generate-yaml=false --version v\$(cat ../../VERSION)"
             // release the helm chart
-            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
+            sh "export VERSION=`cat VERSION` && cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
             }
           }
         }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -39,7 +39,7 @@ pipeline {
             sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
             sh "jx step tag --version \$PR_VERSION"
             sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
-            sh "export VERSION=\$PR_VERSION && cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make preview && make print"
 
             script {
                 currentBuild.displayName = PR_VERSION

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -46,6 +46,7 @@ pipeline {
           }
         }
       }
+    }
         
     stage('Build Master') {
       when {
@@ -81,6 +82,7 @@ pipeline {
         }
       }
     }
+
     stage('Push to Artifactory') {
         when {
           branch 'master'
@@ -91,11 +93,11 @@ pipeline {
               sh "jx step changelog --generate-yaml=false --version v\$(cat ../../VERSION)"
               // release the helm chart
               sh "make release && make print"
+            }
           }
         }
       }
     }
-  }
 
   post {
     always {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -36,7 +36,7 @@ pipeline {
             sh "export VERSION=\$PR_VERSION && skaffold build -f skaffold.yaml"
 
             // Build Helm Chart
-            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller") {
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller" {
             sh "jx step changelog --generate-yaml=false --version \$PR_VERSION"
             sh "make preview && make print"
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -99,7 +99,6 @@ pipeline {
           }
         }
       }
-    }
 
   post {
     always {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -36,7 +36,7 @@ pipeline {
             sh "export VERSION=\$PR_VERSION && skaffold build -f skaffold.yaml"
 
             // Build Helm Chart
-            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller" {
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
             sh "jx step changelog --generate-yaml=false --version \$PR_VERSION"
             sh "make preview && make print"
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -39,7 +39,7 @@ pipeline {
             sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
             sh "jx step tag --version \$PR_VERSION"
             sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
-            sh "make preview && make print"
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller && make preview && make print"
 
             script {
                 currentBuild.displayName = PR_VERSION
@@ -55,7 +55,6 @@ pipeline {
           }
       steps {
         container('go') {
-
           sh "git config --global credential.helper store"
           sh "jx step git credentials"
 
@@ -91,15 +90,13 @@ pipeline {
         }
         steps {
           container('go') {
-            dir("$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/$APP_NAME") {
-              sh "jx step changelog --generate-yaml=false --version v\$(cat ../../VERSION)"
-              // release the helm chart
-              sh "make release && make print"
+            sh "jx step changelog --generate-yaml=false --version v\$(cat ../../VERSION)"
+            // release the helm chart
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
             }
           }
         }
       }
-    }
 
   post {
     always {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -47,7 +47,6 @@ pipeline {
           }
         }
       }
-    }
         
     stage('Build Master') {
       when {
@@ -99,6 +98,7 @@ pipeline {
           }
         }
       }
+    }
 
   post {
     always {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -37,7 +37,7 @@ pipeline {
             sh "export VERSION=\$PR_VERSION && skaffold build -f skaffold.yaml"
 
             dir("$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/$APP_NAME") {
-              sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
+              sh "jx step changelog --generate-yaml=false --version \$PR_VERSION"
               // release the helm chart
               sh "make preview && make print"
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -37,7 +37,8 @@ pipeline {
 
             // Build Helm Chart
             sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
-            sh "jx step changelog --generate-yaml=false --version \$PR_VERSION"
+            sh "jx step tag --version \$(cat PR_VERSION)"
+            sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
             sh "make preview && make print"
 
             script {

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -39,7 +39,7 @@ pipeline {
             sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
             sh "jx step tag --version \$PR_VERSION"
             sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
-            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make preview && make print"
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
 
             script {
                 currentBuild.displayName = PR_VERSION

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -24,10 +24,9 @@ pipeline {
             sh "jx step git credentials"
 
             // Make Test
-            // sh "git clone git://github.com/fsa-streamotion/exposecontroller.git \$GOPATH/src/github.com/jenkins-x/exposecontroller"
-            // sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller && make test"
             sh "mkdir -p \$GOPATH/src/github.com/jenkins-x/exposecontroller"
-            sh "cp . \$GOPATH/src/github.com/jenkins-x/exposecontroller"
+            sh "cp -R ./ \$GOPATH/src/github.com/jenkins-x/exposecontroller"
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller && make test"
 
             // Copy binary
             sh "mkdir out"
@@ -36,10 +35,10 @@ pipeline {
             // Build Image and push to ECR
             sh "export VERSION=\$PR_VERSION && skaffold build -f skaffold.yaml"
 
-            dir("$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/$APP_NAME") {
-              sh "jx step changelog --generate-yaml=false --version \$PR_VERSION"
-              // release the helm chart
-              sh "make preview && make print"
+            // Build Helm Chart
+            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller") {
+            sh "jx step changelog --generate-yaml=false --version \$PR_VERSION"
+            sh "make preview && make print"
 
             script {
                 currentBuild.displayName = PR_VERSION
@@ -64,7 +63,8 @@ pipeline {
           sh "jx step tag --version \$(cat VERSION)"
 
           // Build binary
-          sh "git clone git://github.com/fsa-streamotion/exposecontroller.git \$GOPATH/src/github.com/jenkins-x/exposecontroller"
+          sh "mkdir -p \$GOPATH/src/github.com/jenkins-x/exposecontroller"
+          sh "cp -R ./ \$GOPATH/src/github.com/jenkins-x/exposecontroller"
           sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller && make"
           
           // Copy binary

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -37,7 +37,7 @@ pipeline {
 
             // Build Helm Chart
             sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
-            sh "jx step tag --version \$(cat PR_VERSION)"
+            sh "jx step tag --version \$PR_VERSION"
             sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
             sh "make preview && make print"
 

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -34,7 +34,7 @@ pipeline {
             // Build Image and push to ECR
             sh "export VERSION=\$PR_VERSION && skaffold build -f skaffold.yaml"
 
-            dir("charts/$APP_NAME") {
+            dir("$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/$APP_NAME") {
               sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
               // release the helm chart
               sh "make preview && make print"

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -39,7 +39,7 @@ pipeline {
             sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller"
             sh "jx step tag --version \$PR_VERSION"
             sh "jx step changelog --generate-yaml=false --version v\$PR_VERSION"
-            sh "cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
+            sh "export VERSION=\$PR_VERSION && cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
 
             script {
                 currentBuild.displayName = PR_VERSION
@@ -90,7 +90,7 @@ pipeline {
         }
         steps {
           container('go') {
-            sh "jx step changelog --generate-yaml=false --version v\$(cat ../../VERSION)"
+            sh "jx step changelog --generate-yaml=false --version v\$VERSION"
             // release the helm chart
             sh "export VERSION=`cat VERSION` && cd \$GOPATH/src/github.com/jenkins-x/exposecontroller/charts/exposecontroller && make release && make print"
             }

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,8 @@ endif
 	mkdir -p release
 	cp out/exposecontroller-*-amd64* release
 	cp out/exposecontroller-*-arm* release
-	gh-release checksums sha256
-	GITHUB_ACCESS_TOKEN=$(GITHUB_ACCESS_TOKEN) gh-release create jenkins-x/exposecontroller $(VERSION) master v$(VERSION)
+	# gh-release checksums sha256
+	# GITHUB_ACCESS_TOKEN=$(GITHUB_ACCESS_TOKEN) gh-release create jenkins-x/exposecontroller $(VERSION) master v$(VERSION)
 
 
 .PHONY: cross

--- a/charts/exposecontroller/Makefile
+++ b/charts/exposecontroller/Makefile
@@ -3,7 +3,6 @@ CHART_REPO_KEY := helm-virtual
 NAME := exposecontroller
 NAMESPACE := ${NAME}-test
 OS := $(shell uname)
-VERSION ?= $(shell cat ../../VERSION)
 RELEASE_FILENAME := $(NAME)-$(VERSION).tgz
 
 print:

--- a/charts/exposecontroller/Makefile
+++ b/charts/exposecontroller/Makefile
@@ -1,36 +1,27 @@
-CHART_REPO := http://jenkins-x-chartmuseum:8080
+CHART_REPO := https://artifactory.cluster.foxsports-gitops-prod.com.au/artifactory/helm/
+CHART_REPO_KEY := helm-virtual
 NAME := exposecontroller
+NAMESPACE := ${NAME}-test
 OS := $(shell uname)
-VERSION ?= $(shell cat ../../version/VERSION)
-CHARTMUSEUM_CREDS_USR := $(shell cat /builder/home/basic-auth-user 2> /dev/null)
-CHARTMUSEUM_CREDS_PSW := $(shell cat /builder/home/basic-auth-pass 2> /dev/null)
+VERSION ?= $(shell cat ../../VERSION)
 
-setup:
-	minikube addons enable ingress
-	brew install kubernetes-helm
-	helm init
+print:
+	helm template .
 
-build: clean
+preview:
 	helm dependency build
 	helm lint
 
-install: clean build
-	helm install . --name ${NAME}
-	watch kubectl get pods
-
-upgrade: clean build
-	helm upgrade ${NAME} .
-	watch kubectl get pods
-
-delete:
-	helm delete --purge ${NAME}
+release: clean
+	@test -z $(CHARTMUSEUM_CREDS) && printf "Environment variable CHARTMUSEUM_CREDS not found! \n" && exit 1 || exit 0
+	helm dependency build
+	helm lint
+	helm init --client-only
+	helm package .
+	@echo Pushing Chart to Helm repo...
+	@curl --fail -u $(CHARTMUSEUM_CREDS) -X PUT $(CHART_REPO)/$(RELEASE_FILENAME) -T $(RELEASE_FILENAME)
+	@rm -rf ${NAME}*.tgz
 
 clean:
 	rm -rf charts
-	rm -rf ${NAME}*.tgz
-	rm -rf requirements.lock
-
-release: clean build
-	helm package .
-	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(VERSION).tgz" $(CHART_REPO)/api/charts
 	rm -rf ${NAME}*.tgz

--- a/charts/exposecontroller/Makefile
+++ b/charts/exposecontroller/Makefile
@@ -3,7 +3,7 @@ CHART_REPO_KEY := helm-virtual
 NAME := exposecontroller
 NAMESPACE := ${NAME}-test
 OS := $(shell uname)
-RELEASE_FILENAME := $(NAME)-$(VERSION).tgz
+RELEASE_FILENAME := $(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz
 
 print:
 	helm template .

--- a/charts/exposecontroller/Makefile
+++ b/charts/exposecontroller/Makefile
@@ -4,6 +4,7 @@ NAME := exposecontroller
 NAMESPACE := ${NAME}-test
 OS := $(shell uname)
 VERSION ?= $(shell cat ../../VERSION)
+RELEASE_FILENAME := $(NAME)-$(VERSION).tgz
 
 print:
 	helm template .


### PR DESCRIPTION
The final part of this ticket was to also build the Helm Chart and push it to artifactory. Now I have only made Master push to artifactory but have tested the exact command in the PR section (you can find that here http://jenkins.jx.cluster.foxsports-gitops-prod.com.au/blue/organizations/jenkins/fsa-streamotion%2Fexposecontroller/detail/PR-9/23/pipeline/15#step-31-log-30) this is so I know it will work in Master.

Here is the check for normal PRs. It just does some basic checks http://jenkins.jx.cluster.foxsports-gitops-prod.com.au/blue/organizations/jenkins/fsa-streamotion%2Fexposecontroller/detail/PR-9/26/pipeline/15
